### PR TITLE
Sparql api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Program",
-      "program": "${file}"
+      "program": "${workspaceFolder}/index.js"
     },
     {
       "type": "node",

--- a/api/dbpedia.js
+++ b/api/dbpedia.js
@@ -31,5 +31,22 @@ module.exports = {
             }
             callback(error, response, body)
         });
+    },
+
+    sparqlRequest: function(query, callback) {
+        const url = 'https://dbpedia.org/sparql'
+        const defaultGraph = 'http://dbpedia.org'
+
+        var parameters = new Object()
+        parameters.query = query
+        parameters.format = 'application/sparql-results+json'
+
+        request({url: url, qs: parameters}, function (error, response, body) {
+            if(process.env.ENV_VARIABLE === 'dev') {
+                console.log('error:', error); // Print the error if one occurred
+                console.log('statusCode:', response && response.statusCode); // Print the response status code if a response was received
+            }
+            callback(error, response, body)
+        })
     }
 }

--- a/assets/sparql-query.js
+++ b/assets/sparql-query.js
@@ -1,0 +1,19 @@
+$("#runSparql").click(function () {
+    $.get({
+        url: 'dbpedia/sparql',
+        type: 'GET',
+        data: {
+            text: document.getElementById("sparql").value,
+            confidence: 0.5,
+        },
+        dataType: 'json'
+    })
+        .done(function (data) {
+            document.getElementById("results").innerText = JSON.stringify(data);
+        })
+        .fail(function () {
+            alert('Une erreur est survenue')
+        })
+        .always(function (data) {
+        });
+});

--- a/index.html
+++ b/index.html
@@ -35,9 +35,21 @@
                 <span id="annotated"></span>
             </div>
         </div>
+
+        <br/>
+
+        <h1>Effectuer une requête SPARQL sur DBPedia</h1>
+        <textarea name="sparql" class="form-control" id="sparql" cols="30" rows="10"></textarea>
+        <button id="runSparql" class="btn btn-md btn-primary">Exécuter</button>
+        <div class="card">
+            <div class="card-body">
+                <span id="results"></span>
+            </div>
+        </div>
     </div>
 </body>
 
 <script src="assets/spotlight.js"></script>
+<script src="assets/sparql-query.js"></script>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -30,6 +30,16 @@ app.get('/dbpedia/spotlight', function (req, res) {
   })
 })
 
+app.get('/dbpedia/sparql', function (req, res) {
+  if(process.env.ENV_VARIABLE === 'dev') {
+    console.log(req.query.text)
+  }
+  dbpedia.sparqlRequest(req.query.text, function(error, response, body) {
+    res.set('Content-Type', 'application/json')
+    res.send(body)
+  })
+})
+
 app.use('/assets', express.static('assets'));
 
 app.listen(app.get('port'), function() {

--- a/test/test-dbpedia.js
+++ b/test/test-dbpedia.js
@@ -32,4 +32,15 @@ describe('DBpedia', function () {
             done()
         })
     })
+
+    it('should correctly respond to a SPARQL request', (done) => {
+        chai.request(server)
+        .get('/dbpedia/sparql')
+        .query({text: 'select distinct ?Concept where {[] a ?Concept} LIMIT 100'})
+        .end((err, res) => {
+            res.should.have.status(200)
+            res.body.should.have.property('results')
+            done()
+        })
+    })
 })


### PR DESCRIPTION
Closes #2

Cette pr permet maintenant de faire des requêtes SPARQL à DBPedia. Bon, après, je sais pas trop comment interpréter ces résultats, mais c'est là.