### PR TITLE
DBPedia/annotate renvoie maintenant du json

### DIFF
--- a/api/dbpedia.js
+++ b/api/dbpedia.js
@@ -7,12 +7,17 @@ module.exports = {
         const parameters = {
             text: query
         }
+
+        const headers = {
+            Accept: 'application/json'
+        }
     
-        request({url: url, qs: parameters}, function (error, response, body) {
+        request({headers: headers, url: url, qs: parameters}, function (error, response, body) {
             if(process.env.ENV_VARIABLE === 'dev') {
                 console.log('error:', error); // Print the error if one occurred
                 console.log('statusCode:', response && response.statusCode); // Print the response status code if a response was received
             }
+            body = JSON.parse(body)
             callback(error, response, body)
         });
     },

--- a/test/test-dbpedia.js
+++ b/test/test-dbpedia.js
@@ -19,7 +19,11 @@ describe('DBpedia', function () {
         .query({text: 'Lyon'})
         .end((err, res) => {
             res.should.have.status(200)
-            res.text.should.be.a('string').that.includes('<a about=\\"http://dbpedia.org/resource/Lyon\\" typeof=\\"http://dbpedia.org/ontology/Settlement\\" href=\\"http://dbpedia.org/resource/Lyon\\" title=\\"http://dbpedia.org/resource/Lyon\\">Lyon</a>')
+            res.should.have.property('body')
+            res.body.body.should.have.property('Resources')
+            res.body.body.Resources.should.be.an('Array')
+            res.body.body.Resources[0].should.have.property('@URI')
+            res.body.body.Resources[0]['@URI'].should.equals('http://dbpedia.org/resource/Lyon')
             done()
         })
     })


### PR DESCRIPTION
Changement : renvoie du json et plus de l'HTML annoté comme avant